### PR TITLE
update to new batch size

### DIFF
--- a/cloudmetrics/backends/cloudwatch_backend.py
+++ b/cloudmetrics/backends/cloudwatch_backend.py
@@ -7,7 +7,7 @@ from . import MetricsBackend
 
 
 # This limit is defined by Amazon. Don't change it unless they do.
-AWS_MAX_BATCH_SIZE = 10
+AWS_MAX_BATCH_SIZE = 20
 
 
 # This relies on boto being configured:


### PR DESCRIPTION
new maximum batch size appears to be 20: http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html